### PR TITLE
feat: added cli-version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ jobs:
       - name: Pizza Action
         uses: open-sauced/pizza-action@v1.0.0
         with:
-          # optional and false by default
+          # optional and default is "@latest". Add this parameter if you want to use a specific version, e.g. v2.0.0
+          cli-version: "@v2.0.0"
+          # optional and false by default. Set this to true if you want to have a pull request for the changes created automatically.
           commit-and-pr: "true"
           # optional
           pr-title: "chore: update repository codeowners"
@@ -39,6 +41,10 @@ Depending on the pizza CLI command you run, different things will update. For ex
 The pizza CLI's "generate codeowners ./ --tty-disable" command requires a full repository history to accurately determine code ownership over time. Fetch-depth is set to 0 in this action to ensure all historical commits are available, allowing the command to analyze the entire project timeline and produce a comprehensive CODEOWNERS file.
 
 ## Inputs
+
+### `cli-version`
+
+The version of the pizza CLI to use. Default is `@latest`. If using a numbered version, make sure to include the `@` symbol as well as a `v` before the version number. For example, `@v2.0.0`.
 
 ### `pizza-args`
 

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,14 @@ branding:
   icon: "package"
   color: "orange"
 inputs:
+  cli-version:
+    description: "OpenSauced Pizza CLI version to use"
+    default: "@latest"
+    required: false
   pizza-args:
     description: "OpenSauced Pizza CLI command to run"
     default: "generate codeowners ./ --tty-disable"
-    required: true
+    required: false
   commit-and-pr:
     description: "Commit and push changes"
     default: "false"
@@ -32,7 +36,7 @@ runs:
 
     - name: Install pizza CLI
       run: |
-        go install github.com/open-sauced/pizza-cli@beta
+        go install github.com/open-sauced/pizza-cli${{ inputs.cli-version }}
       shell: bash
 
     - name: Check pizza CLI version


### PR DESCRIPTION
## Description

Adds a cli-version parameter to the pizza-action GitHub action. The GitHub action is pretty much feature complete and there is no reason to update the action's version if the pizza CLI version gets updated.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes #4

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

I've tested this on my test repo with `@latest`, `@beta`, `@v1.4.0` and each time the action ran, it pulled the correct version.

## Added to documentation?

- [x] 📜 README.md
- [ ] 📜 CONTRIBUTING.md
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/3WCNY2RhcmnwGbKbCi/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
